### PR TITLE
Update INFINITI G Sedan generations: Added Wikipedia reference and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# INFINITI G Sedan
 
+This repository contains signal set configurations for the INFINITI G Sedan, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the INFINITI G Sedan.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Infiniti_G"
+
 generations:
   - name: "First Generation (P10)"
     start_year: 1991


### PR DESCRIPTION
- Added references section with Infiniti G Wikipedia article
- Updated README.md with standard template
- Verified generations data against Wikipedia (P10, P11, V35, V36)
- Confirmed production years: 1991-1996, 1999-2002, 2003-2006, 2007-2013
